### PR TITLE
Make InvalidBookmarkSyntaxError easier to find

### DIFF
--- a/pdf_bookmark.py
+++ b/pdf_bookmark.py
@@ -376,7 +376,7 @@ def _split_title_page(title_page):
     start_pos = title_page.find('.'*_CONTENT_MINIMUM_DOTS)
     if start_pos < 0:
         raise InvalidBookmarkSyntaxError(
-            'There must be at least {} "." specified'.format(_CONTENT_MINIMUM_DOTS))
+            'There must be at least {} "." specified in the line "{}"'.format(_CONTENT_MINIMUM_DOTS,title_page))
 
     end_pos = start_pos + _CONTENT_MINIMUM_DOTS
     for c in title_page[start_pos+_CONTENT_MINIMUM_DOTS:]:


### PR DESCRIPTION
I was using pdf-bookmark with a long .bmk file where I had forgotten to add page numbers to a couple of lines and there isn't a simple way to find a syntax error in the file. By providing the text from the line, the user should be able to quickly find and fix the problematic line.