### PR TITLE
Fix unexpected page rotating

### DIFF
--- a/pdf_bookmark.py
+++ b/pdf_bookmark.py
@@ -585,7 +585,7 @@ def generate_pdf(pdfmark, pdf, output_pdf):
     pdfmark_restore = _write_pdfmark_restore_file()
     pdfmark_pagemode = _write_pdfmark_pagemode()
 
-    call(['gs', '-dBATCH', '-dNOPAUSE', '-sDEVICE=pdfwrite',
+    call(['gs', '-dBATCH', '-dNOPAUSE', '-sDEVICE=pdfwrite', '-dAutoRotatePages=/None',
           '-sOutputFile={}'.format(output_pdf),
           pdfmark_noop,
           pdf,


### PR DESCRIPTION
Summary: I added the option -dAutoRotatePages=/None to the call to Ghostscript to prevent it from auto-rotating pages; this utility is for bookmarks, so it is unexpected behaviour when pdf-bookmark changes the rotation of pages.

I spent quite a bit of time trying to understand why some of the pages of the pdf I was working with were rotating unexpectedly. The particular PDF I was using contains scanned pages. I think Ghostscript incorrectly recognizes some of those pages as having sideways text, so a default call to Ghostscript rotates those pages incorrectly.

I could add an option to pdf-bookmark to use or not use autorotation, but I think the most expected behaviour for pdf-bookmark would be for it to import the bookmarks while leaving page rotation alone.